### PR TITLE
fix: handle additional cases for search param parsing

### DIFF
--- a/src/electron.ts
+++ b/src/electron.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, shell } from "electron"
 import path from "path"
 import "./webview.ts"
 import type { AccessTokenChangedParams } from "./preload"
+import { getSearch } from "./util/urlParse"
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -89,8 +90,9 @@ if (!app.requestSingleInstanceLock()) {
 		}
 
 		const arg = commandLine.pop()
-		if (arg?.startsWith("mautrix-manager://sso?")) {
-			loadIndexPage(arg.replace("mautrix-manager://sso?", ""))
+		const search = getSearch(arg)
+		if (search){
+			loadIndexPage(search)
 		}
 	})
 
@@ -109,8 +111,9 @@ if (!app.requestSingleInstanceLock()) {
 	app.whenReady().then(createWindow)
 
 	app.on("open-url", (event, url) => {
-		if (url.startsWith("mautrix-manager://sso?")) {
-			loadIndexPage(url.replace("mautrix-manager://sso?", ""))
+		const search = getSearch(url)
+		if (search){
+			loadIndexPage(search)
 		}
 	})
 }

--- a/src/util/urlParse.ts
+++ b/src/util/urlParse.ts
@@ -1,0 +1,5 @@
+export function getSearch(url: string | undefined): string | undefined {
+	if (url?.startsWith("mautrix-manager://sso?") || url?.startsWith("mautrix-manager://sso/?")) {
+		return url.replace("mautrix-manager://sso?", "").replace("mautrix-manager://sso/?", "")
+	}
+}


### PR DESCRIPTION
on Windows 10+Firefox, the custom protocol URL sometimes comes with a trailing slash before the search params

This prevents the manager from properly receiving the login code from the SSO login session.