### PR TITLE
Add support for building flatpak images

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,6 +1,7 @@
 import type { ForgeConfig } from "@electron-forge/shared-types"
 import { MakerSquirrel } from "@electron-forge/maker-squirrel"
 import { MakerDMG } from "@electron-forge/maker-dmg"
+import { MakerFlatpak } from "@electron-forge/maker-flatpak"
 import { MakerDeb } from "@electron-forge/maker-deb"
 import { PublisherGithub } from "@electron-forge/publisher-github"
 import { VitePlugin } from "@electron-forge/plugin-vite"
@@ -31,6 +32,15 @@ const config: ForgeConfig = {
 		new MakerDeb({
 			options: {
 				mimeType: ["x-scheme-handler/mautrix-manager"],
+				icon: "icon.png",
+			},
+		}),
+		new MakerFlatpak({
+			options: {
+				id: "net.maunium.electron",
+				productName: "mautrix-manager",
+				mimeType: ["x-scheme-handler/mautrix-manager"],
+				categories: ["Network"],
 				icon: "icon.png",
 			},
 		}),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mautrix-manager",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mautrix-manager",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"electron-squirrel-startup": "^1.0.1",
@@ -19,6 +19,7 @@
 				"@electron-forge/cli": "^7.11.1",
 				"@electron-forge/maker-deb": "^7.11.1",
 				"@electron-forge/maker-dmg": "^7.11.1",
+				"@electron-forge/maker-flatpak": "^7.11.2",
 				"@electron-forge/maker-rpm": "^7.11.1",
 				"@electron-forge/maker-squirrel": "^7.11.1",
 				"@electron-forge/maker-zip": "^7.11.1",
@@ -463,6 +464,68 @@
 			},
 			"optionalDependencies": {
 				"electron-installer-dmg": "^5.0.1"
+			}
+		},
+		"node_modules/@electron-forge/maker-flatpak": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-flatpak/-/maker-flatpak-7.11.2.tgz",
+			"integrity": "sha512-tc/lw1NVB8AGIVEozccFK4BR1oj9GTdV2tH+HDD6WSqvB4mjBKVKWjeR+8En3I546dnI/qWodtSN/OiL2ZTqIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron-forge/maker-base": "7.11.2",
+				"@electron-forge/shared-types": "7.11.2",
+				"fs-extra": "^10.0.0"
+			},
+			"engines": {
+				"node": ">= 16.4.0"
+			},
+			"optionalDependencies": {
+				"@malept/electron-installer-flatpak": "^0.11.4"
+			}
+		},
+		"node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/maker-base": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.2.tgz",
+			"integrity": "sha512-9934zYu9WVdgCYQXvtS+eL1oyLagsY8JlWhZmoK8yWTYftSAydH7jb3seVpfy6n85SYmY/yjcAy2lvOTy5dUwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron-forge/shared-types": "7.11.2",
+				"fs-extra": "^10.0.0",
+				"which": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 16.4.0"
+			}
+		},
+		"node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/shared-types": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.2.tgz",
+			"integrity": "sha512-Tcles7y74xy3jN5dEC+Pt1duJYk4c7W2xu98tjWW8RewmfKD2uHkie6I1I3yifPFZXZ/QfTlaFOOoKIQ9ENZjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@electron-forge/tracer": "7.11.2",
+				"@electron/packager": "^18.3.5",
+				"@electron/rebuild": "^3.7.0",
+				"listr2": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 16.4.0"
+			}
+		},
+		"node_modules/@electron-forge/maker-flatpak/node_modules/@electron-forge/tracer": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.2.tgz",
+			"integrity": "sha512-U8j5Hyj2Zt7I5PciJvPJfmEv69Gb/Da9v+k655z3Jj1cuY0UnToEJ61IhXrzlTYqo+jUKC+fgAjDJ6vltJTS0A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chrome-trace-event": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 14.17.5"
 			}
 		},
 		"node_modules/@electron-forge/maker-rpm": {
@@ -1751,6 +1814,164 @@
 				"node": ">= 12.13.0"
 			}
 		},
+		"node_modules/@malept/electron-installer-flatpak": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/@malept/electron-installer-flatpak/-/electron-installer-flatpak-0.11.4.tgz",
+			"integrity": "sha512-ZdwhT4WeeJWdnsmALUtQ7bn4pzYVh0Vg+4NnF1S3n3OACc9IWg+B+LxI5gT3XSXIrxogouqkjM6gD8S592awyA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin",
+				"linux"
+			],
+			"dependencies": {
+				"@malept/flatpak-bundler": "^0.4.0",
+				"debug": "^4.1.1",
+				"electron-installer-common": "^0.10.0",
+				"lodash": "^4.17.15",
+				"semver": "^7.1.1",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"electron-installer-flatpak": "bin/electron-installer-flatpak.js"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@malept/electron-installer-flatpak/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@malept/flatpak-bundler": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+			"integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"fs-extra": "^9.0.0",
+				"lodash": "^4.17.15",
+				"tmp-promise": "^3.0.2"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -2261,9 +2482,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2281,9 +2499,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2301,9 +2516,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2321,9 +2533,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2341,9 +2550,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2361,9 +2567,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7441,9 +7644,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7465,9 +7665,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7489,9 +7686,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7513,9 +7707,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@electron-forge/cli": "^7.11.1",
 		"@electron-forge/maker-deb": "^7.11.1",
 		"@electron-forge/maker-dmg": "^7.11.1",
+		"@electron-forge/maker-flatpak": "^7.11.2",
 		"@electron-forge/maker-rpm": "^7.11.1",
 		"@electron-forge/maker-squirrel": "^7.11.1",
 		"@electron-forge/maker-zip": "^7.11.1",


### PR DESCRIPTION
I use arch, so I can't use use the .deb packages, and building locally doesn't really give you the schema stuff needed to do sso logins properly

So looked it up, electron has a flatpak builder.

Super basic setup, builds the flatpak package, uploads it as normal, nothing super fancy, but should cover any os that isn't debian based.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
