### PR TITLE
Fix packaging of WebAuthn native module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Build app
         run: npm run make
 
+      - name: Verify packaged dependencies
+        run: npm run verify:package
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -12,6 +12,16 @@ const config: ForgeConfig = {
 		asar: {
 			unpack: "**/*.node",
 		},
+		// Vite externalizes the native WebAuthn module, so Electron Packager must copy it.
+		// Disable its dependency pruning and explicitly retain only this package and its
+		// platform-specific optional dependency to avoid duplicating bundled modules.
+		prune: false,
+		ignore: (file) => Boolean(file && !(
+			file.startsWith("/.vite")
+			|| file === "/node_modules"
+			|| file === "/node_modules/@beeper"
+			|| file.startsWith("/node_modules/@beeper/webauthn-authenticator")
+		)),
 		protocols: [
 			{
 				name: "mautrix-manager",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@electron-forge/plugin-fuses": "^7.11.1",
 				"@electron-forge/plugin-vite": "^7.11.1",
 				"@electron-forge/publisher-github": "^7.11.1",
+				"@electron/asar": "^3.4.1",
 				"@electron/fuses": "^1.8.0",
 				"@types/electron-squirrel-startup": "^1.0.2",
 				"@types/react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"start": "electron-forge start",
 		"package": "electron-forge package",
+		"verify:package": "node scripts/verify-package.mjs",
 		"make": "electron-forge make",
 		"publish": "electron-forge publish",
 		"lint": "tsc --noEmit && eslint --ext .ts,.tsx ."
@@ -22,6 +23,7 @@
 		"@electron-forge/plugin-fuses": "^7.11.1",
 		"@electron-forge/plugin-vite": "^7.11.1",
 		"@electron-forge/publisher-github": "^7.11.1",
+		"@electron/asar": "^3.4.1",
 		"@electron/fuses": "^1.8.0",
 		"@types/electron-squirrel-startup": "^1.0.2",
 		"@types/react": "^19.1.0",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readdirSync, statSync } from "node:fs"
+import path from "node:path"
+import { createRequire } from "node:module"
+
+const require = createRequire(import.meta.url)
+const { listPackage } = require("@electron/asar")
+
+const nativePackageByTarget = {
+	"darwin-arm64": "webauthn-authenticator-darwin-arm64",
+	"darwin-x64": "webauthn-authenticator-darwin-x64",
+	"linux-arm64": "webauthn-authenticator-linux-arm64-gnu",
+	"linux-x64": "webauthn-authenticator-linux-x64-gnu",
+	"win32-arm64": "webauthn-authenticator-win32-arm64-msvc",
+	"win32-x64": "webauthn-authenticator-win32-x64-msvc",
+}
+
+function findFiles(root, basename) {
+	if (!existsSync(root)) {
+		return []
+	}
+	const matches = []
+	for (const entry of readdirSync(root, { withFileTypes: true })) {
+		const entryPath = path.join(root, entry.name)
+		if (entry.isDirectory()) {
+			matches.push(...findFiles(entryPath, basename))
+		} else if (entry.name === basename) {
+			matches.push(entryPath)
+		}
+	}
+	return matches
+}
+
+const target = `${process.platform}-${process.arch}`
+const nativePackage = nativePackageByTarget[target]
+if (!nativePackage) {
+	throw new Error(`Unsupported package verification target: ${target}`)
+}
+
+const asarPaths = findFiles(path.resolve("out"), "app.asar")
+if (asarPaths.length !== 1) {
+	throw new Error(`Expected exactly one packaged app.asar, found ${asarPaths.length}`)
+}
+
+const asarPath = asarPaths[0]
+const entries = new Set(listPackage(asarPath))
+const requiredEntries = [
+	"/node_modules/@beeper/webauthn-authenticator/package.json",
+	"/node_modules/@beeper/webauthn-authenticator/index.js",
+	`/node_modules/@beeper/${nativePackage}/package.json`,
+]
+for (const entry of requiredEntries) {
+	if (!entries.has(entry)) {
+		throw new Error(`Packaged app is missing ${entry}`)
+	}
+}
+
+const nativeRoot = `${asarPath}.unpacked/node_modules/@beeper/${nativePackage}`
+const nativeBinaries = existsSync(nativeRoot)
+	? readdirSync(nativeRoot)
+		.filter((name) => name.endsWith(".node"))
+		.map((name) => path.join(nativeRoot, name))
+		.filter((file) => statSync(file).isFile())
+	: []
+if (nativeBinaries.length !== 1) {
+	throw new Error(`Expected one unpacked native WebAuthn binary, found ${nativeBinaries.length}`)
+}
+
+console.log(`Verified packaged WebAuthn dependency for ${target}`)


### PR DESCRIPTION
## Summary

- retain the externalized `@beeper/webauthn-authenticator` package and its platform-specific native dependency during Electron Forge packaging
- keep the native `.node` binary unpacked from ASAR
- add a cross-platform packaged-app check for the JavaScript loader, target-specific package, and unpacked native binary
- run that verification after each build workflow package

## Root cause

The Vite main-process build correctly externalizes the native WebAuthn module, but the Vite plugin's default Electron Packager ignore callback only retains `.vite`. As a result, the released app had no `node_modules` entries and crashed immediately when Electron evaluated `require("@beeper/webauthn-authenticator")`.

The custom filter retains `.vite`, the WebAuthn package, and its target-specific optional dependency. Electron Packager pruning is disabled because the filter already selects only those external runtime files; this avoids duplicating other production dependencies that Vite has bundled.

## Verification

- [x] Regression check failed against the unmodified v0.2.0 package because the WebAuthn package was absent
- [x] `npm run lint`
- [x] macOS ARM64 `electron-forge package`
- [x] `npm run verify:package`
- [x] macOS ARM64 `electron-forge make` produced a DMG
- [x] packaged app launched and remained running without the missing-module exception
- [x] independent pre-commit review passed with no blocking findings

Fixes #11
